### PR TITLE
Fix scrollable related issues that were happening on android

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ Additionally, reanimated-tab-view also provides the following features
 
 - Collapsible headers
 
-  <img src="./assets/collapsible_header.gif" width="360">
+  - Currently supported on ios and android
+    <img src="./assets/collapsible_header.gif" width="360">
 
 - 3 render modes to render the tab view ("all", "windowed" and "lazy"). Can be modified using the `renderMode` prop.
 

--- a/src/components/Scrollable/RTVRefreshControl.tsx
+++ b/src/components/Scrollable/RTVRefreshControl.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { RefreshControl } from 'react-native';
+import type { RefreshControlProps } from 'react-native';
+import { useRefreshControl } from '../../hooks/scrollable/useRefreshControl';
+
+export const RTVRefreshControl = React.memo(function RTVRefreshControl(
+  props: RefreshControlProps
+) {
+  const { progressViewOffset } = useRefreshControl();
+  return <RefreshControl {...props} progressViewOffset={progressViewOffset} />;
+});

--- a/src/components/Scrollable/RTVScrollView.tsx
+++ b/src/components/Scrollable/RTVScrollView.tsx
@@ -47,7 +47,10 @@ export const RTVScrollView = React.memo(
     const scrollRef = useAnimatedRef<Animated.ScrollView>();
 
     const scrollGesture = useMemo(
-      () => Gesture.Native().shouldCancelWhenOutside(false),
+      () =>
+        Gesture.Native()
+          .shouldCancelWhenOutside(false)
+          .disallowInterruption(true),
       []
     );
 

--- a/src/components/Scrollable/RTVScrollView.tsx
+++ b/src/components/Scrollable/RTVScrollView.tsx
@@ -7,15 +7,17 @@ import Animated, {
   useAnimatedStyle,
   useSharedValue,
 } from 'react-native-reanimated';
+import { StyleSheet } from 'react-native';
+import type {
+  ScrollView,
+  NativeSyntheticEvent,
+  NativeScrollEvent,
+} from 'react-native';
 
 import { useScrollableContext } from '../../providers/Scrollable';
 import { useInternalContext } from '../../providers/Internal';
-import { StyleSheet } from 'react-native';
 import { useScrollHandlers } from '../../hooks/scrollable/useScrollHandlers';
 import { useSyncScrollWithPanTranslation } from '../../hooks/scrollable/useSyncScrollWithPanTranslation';
-import type { ScrollView } from 'react-native';
-import type { NativeSyntheticEvent } from 'react-native';
-import type { NativeScrollEvent } from 'react-native';
 import { SHOULD_RENDER_ABSOLUTE_HEADER } from '../../constants/scrollable';
 
 export const RTVScrollView = React.memo(

--- a/src/components/Scrollable/index.ts
+++ b/src/components/Scrollable/index.ts
@@ -1,2 +1,3 @@
 export * from './RTVScrollView';
 export * from './RTVFlatList';
+export * from './RTVRefreshControl';

--- a/src/components/TabView.tsx
+++ b/src/components/TabView.tsx
@@ -28,6 +28,7 @@ import { TabViewHeader } from './TabViewHeader';
 import { ScrollableContextProvider } from '../providers/Scrollable';
 import { useGestureContentTranslateYStyle } from '../hooks/scrollable/useGestureContentTranslateYStyle';
 import { useScrollLikePanGesture } from '../hooks/scrollable/useScrollLikePanGesture';
+import { SHOULD_RENDER_ABSOLUTE_HEADER } from '../constants/scrollable';
 
 export const TabViewWithoutProviders = React.memo(() => {
   //#region context
@@ -44,7 +45,7 @@ export const TabViewWithoutProviders = React.memo(() => {
     return { width };
   }, [tabViewLayout]);
 
-  const contentStyle = useMemo(() => {
+  const translatingTabViewContentStyle = useMemo(() => {
     return tabViewLayout.height
       ? {
           height: tabViewLayout.height,
@@ -98,19 +99,41 @@ export const TabViewWithoutProviders = React.memo(() => {
 
   //#region render
   return (
-    <GestureDetector gesture={scrollLikePanGesture}>
-      <View
-        style={[styles.container, containerLayoutStyle]}
-        onLayout={onTabViewLayout}
-      >
-        <TabViewHeader style={animatedTranslateYStyle} />
-        <Animated.View style={[contentStyle, animatedTranslateYStyle]}>
-          {tabBarPosition === 'top' && tabBar}
+    <>
+      {SHOULD_RENDER_ABSOLUTE_HEADER ? (
+        <View
+          style={[styles.container, containerLayoutStyle]}
+          onLayout={onTabViewLayout}
+        >
+          <View style={styles.absoluteHeaderContainer}>
+            <GestureDetector gesture={scrollLikePanGesture}>
+              <Animated.View style={animatedTranslateYStyle}>
+                <TabViewHeader />
+                {tabBarPosition === 'top' && tabBar}
+                {tabBarPosition === 'bottom' && tabBar}
+              </Animated.View>
+            </GestureDetector>
+          </View>
           <TabViewCarousel ref={tabViewCarouselRef} />
-          {tabBarPosition === 'bottom' && tabBar}
-        </Animated.View>
-      </View>
-    </GestureDetector>
+        </View>
+      ) : (
+        <GestureDetector gesture={scrollLikePanGesture}>
+          <View
+            style={[styles.container, containerLayoutStyle]}
+            onLayout={onTabViewLayout}
+          >
+            <TabViewHeader style={animatedTranslateYStyle} />
+            <Animated.View
+              style={[translatingTabViewContentStyle, animatedTranslateYStyle]}
+            >
+              {tabBarPosition === 'top' && tabBar}
+              <TabViewCarousel ref={tabViewCarouselRef} />
+              {tabBarPosition === 'bottom' && tabBar}
+            </Animated.View>
+          </View>
+        </GestureDetector>
+      )}
+    </>
   );
   //#endregion
 });
@@ -317,5 +340,13 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     overflow: 'hidden',
+  },
+  absoluteHeaderContainer: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    zIndex: 1,
   },
 });

--- a/src/constants/scrollable.ts
+++ b/src/constants/scrollable.ts
@@ -18,3 +18,5 @@ export enum ScrollableType {
   SECTION_LIST = 'SECTION_LIST',
   FLASH_LIST = 'FLASH_LIST',
 }
+
+export const SHOULD_RENDER_ABSOLUTE_HEADER = Platform.OS === 'android';

--- a/src/constants/scrollable.ts
+++ b/src/constants/scrollable.ts
@@ -2,7 +2,7 @@ import { Platform } from 'react-native';
 
 export const DECELERATION_RATE_FOR_SCROLLVIEW = Platform.select({
   ios: 0.9998,
-  android: 0.985,
+  android: 0.9985,
   default: 1,
 });
 

--- a/src/hooks/scrollable/useRefreshControl.ts
+++ b/src/hooks/scrollable/useRefreshControl.ts
@@ -1,0 +1,14 @@
+import { SHOULD_RENDER_ABSOLUTE_HEADER } from '../../constants/scrollable';
+import { useInternalContext } from '../../providers/Internal';
+
+export const useRefreshControl = () => {
+  //#region context
+  const { tabViewHeaderLayout, tabBarLayout } = useInternalContext();
+  //#endregion
+
+  return {
+    progressViewOffset: SHOULD_RENDER_ABSOLUTE_HEADER
+      ? tabViewHeaderLayout.height + tabBarLayout.height
+      : 0,
+  };
+};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,4 +2,6 @@ export * from './components/TabView';
 export * from './components/Scrollable';
 export * from './components/TabBar';
 
+export * from './hooks/scrollable/useRefreshControl';
+
 export * from './types';


### PR DESCRIPTION
For ios, the translation effect of Scrollable was implemented by translating the content container in the opposite direction of motion. This made it look like the scrollable was not actually scrolling until the tab bar latches to the top of the screen.

The same isn't possible with android.
When we translate the content container of a scrollable on android, it messes up with the native gesture handler of the scrollable. We can't achieve the same effect using the method we used with ios.

So, instead of translating the content container, I now made it non translational. I absolutely placed the header etc on top of the scrollable and gave the scrollable some offset on the top.

https://github.com/user-attachments/assets/f1e94581-d40c-4825-8eb8-00202df9118b

